### PR TITLE
Allow styling through 'className' prop

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ const fontSize = (size) => {
 };
 
 const SimpleLineIcon = ({
+  className,
   name,
   color,
   size,
@@ -19,7 +20,7 @@ const SimpleLineIcon = ({
   ...rest
 }) => (
   <div
-    className={`icon-${name}`}
+    className={`icon-${name} ${className}`}
     style={{
       color,
       fontSize: fontSize(size),
@@ -31,12 +32,14 @@ const SimpleLineIcon = ({
 
 SimpleLineIcon.propTypes = {
   name: PropTypes.string.isRequired,
+  className: PropTypes.string,
   color: PropTypes.string,
   size: PropTypes.oneOf(['Large', 'large', 'Medium', 'medium', 'Small', 'small']),
   style: PropTypes.object,
 };
 
 SimpleLineIcon.defaultProps = {
+  className:"",
   color: null,
   size: 'Medium',
   style: {},


### PR DESCRIPTION
- added support to pass 'className' as a prop for css based styling
   e,g, <SimpleLineIcon name="refresh" color="red" className="form-label-elem"/>
- Doesn't affect icon-name usage.
- Added classNames to propTypes as non-required.
- Added className defaultProps as an empty String.